### PR TITLE
feat: 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,17 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// javamail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// EmailValidator
+	implementation 'commons-validator:commons-validator:1.7'
+
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/mymusiclist/backend/MyMusiclistApplication.java
+++ b/src/main/java/com/mymusiclist/backend/MyMusiclistApplication.java
@@ -1,13 +1,13 @@
-package com.mymusiclist.mymusiclist;
+package com.mymusiclist.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class MymusiclistApplication {
+public class MyMusiclistApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(MymusiclistApplication.class, args);
+		SpringApplication.run(MyMusiclistApplication.class, args);
 	}
 
 }

--- a/src/main/java/com/mymusiclist/backend/components/MailComponents.java
+++ b/src/main/java/com/mymusiclist/backend/components/MailComponents.java
@@ -1,0 +1,33 @@
+package com.mymusiclist.backend.components;
+
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MailComponents {
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendMail(String email, String title, String text) {
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(message, true, "UTF-8");
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject(title);
+            mimeMessageHelper.setText(text, true);
+
+        } catch (MessagingException e) {
+
+            throw new RuntimeException(e);
+        }
+
+        javaMailSender.send(message);
+    }
+}

--- a/src/main/java/com/mymusiclist/backend/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/mymusiclist/backend/configuration/SecurityConfiguration.java
@@ -1,0 +1,32 @@
+package com.mymusiclist.backend.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+    return http
+        .csrf(AbstractHttpConfigurer::disable)
+        .authorizeHttpRequests(
+            requests -> requests.requestMatchers("/", "/member/signup", "/member/auth").permitAll())
+        .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
+            SessionCreationPolicy.STATELESS)).build();
+  }
+
+  @Bean
+  public PasswordEncoder PasswordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/com/mymusiclist/backend/exception/AbstractException.java
+++ b/src/main/java/com/mymusiclist/backend/exception/AbstractException.java
@@ -1,0 +1,9 @@
+package com.mymusiclist.backend.exception;
+
+public abstract class AbstractException extends RuntimeException {
+
+  abstract public int getStatusCode();
+
+  abstract public String getMessage();
+
+}

--- a/src/main/java/com/mymusiclist/backend/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/mymusiclist/backend/exception/CustomExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.mymusiclist.backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class CustomExceptionHandler {
+
+  @ExceptionHandler(AbstractException.class)
+  protected ResponseEntity<ErrorResponse> handleCustomException(AbstractException e) {
+
+    ErrorResponse errorResponse = ErrorResponse.builder()
+        .code(e.getStatusCode())
+        .message(e.getMessage())
+        .build();
+
+    return new ResponseEntity<>(errorResponse, HttpStatus.resolve(e.getStatusCode()));
+  }
+
+}

--- a/src/main/java/com/mymusiclist/backend/exception/ErrorResponse.java
+++ b/src/main/java/com/mymusiclist/backend/exception/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.mymusiclist.backend.exception;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ErrorResponse {
+
+  private int code;
+  private String message;
+}

--- a/src/main/java/com/mymusiclist/backend/exception/impl/DuplicateEmailException.java
+++ b/src/main/java/com/mymusiclist/backend/exception/impl/DuplicateEmailException.java
@@ -1,0 +1,17 @@
+package com.mymusiclist.backend.exception.impl;
+
+import com.mymusiclist.backend.exception.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateEmailException extends AbstractException {
+
+  @Override
+  public int getStatusCode() {
+    return HttpStatus.BAD_REQUEST.value();
+  }
+
+  @Override
+  public String getMessage() {
+    return "이미 존재하는 이메일입니다.";
+  }
+}

--- a/src/main/java/com/mymusiclist/backend/exception/impl/InvalidAuthCodeException.java
+++ b/src/main/java/com/mymusiclist/backend/exception/impl/InvalidAuthCodeException.java
@@ -1,0 +1,17 @@
+package com.mymusiclist.backend.exception.impl;
+
+import com.mymusiclist.backend.exception.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidAuthCodeException extends AbstractException {
+
+  @Override
+  public int getStatusCode() {
+    return HttpStatus.BAD_REQUEST.value();
+  }
+
+  @Override
+  public String getMessage() {
+    return "유효하지 않는 인증 코드입니다.";
+  }
+}

--- a/src/main/java/com/mymusiclist/backend/exception/impl/InvalidEmailException.java
+++ b/src/main/java/com/mymusiclist/backend/exception/impl/InvalidEmailException.java
@@ -1,0 +1,17 @@
+package com.mymusiclist.backend.exception.impl;
+
+import com.mymusiclist.backend.exception.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidEmailException extends AbstractException {
+
+  @Override
+  public int getStatusCode() {
+    return HttpStatus.BAD_REQUEST.value();
+  }
+
+  @Override
+  public String getMessage() {
+    return "유효하지 않는 이메일 입니다. 이메일을 다시 한번 확인해주세요.";
+  }
+}

--- a/src/main/java/com/mymusiclist/backend/exception/impl/InvalidPasswordConfirmationException.java
+++ b/src/main/java/com/mymusiclist/backend/exception/impl/InvalidPasswordConfirmationException.java
@@ -1,0 +1,17 @@
+package com.mymusiclist.backend.exception.impl;
+
+import com.mymusiclist.backend.exception.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidPasswordConfirmationException extends AbstractException {
+
+  @Override
+  public int getStatusCode() {
+    return HttpStatus.BAD_REQUEST.value();
+  }
+
+  @Override
+  public String getMessage() {
+    return "비밀번호와 확인용 비밀번호가 다릅니다.";
+  }
+}

--- a/src/main/java/com/mymusiclist/backend/exception/impl/NotFoundMemberException.java
+++ b/src/main/java/com/mymusiclist/backend/exception/impl/NotFoundMemberException.java
@@ -1,0 +1,17 @@
+package com.mymusiclist.backend.exception.impl;
+
+import com.mymusiclist.backend.exception.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundMemberException extends AbstractException {
+
+  @Override
+  public int getStatusCode() {
+    return HttpStatus.NOT_FOUND.value();
+  }
+
+  @Override
+  public String getMessage() {
+    return "존재하지 않는 회원입니다.";
+  }
+}

--- a/src/main/java/com/mymusiclist/backend/member/controller/MemberController.java
+++ b/src/main/java/com/mymusiclist/backend/member/controller/MemberController.java
@@ -1,0 +1,33 @@
+package com.mymusiclist.backend.member.controller;
+
+import com.mymusiclist.backend.member.dto.parameter.SignUpParameter;
+import com.mymusiclist.backend.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class MemberController {
+
+  private final MemberService memberService;
+
+  @PostMapping("/signup")
+  public ResponseEntity<String> singUp(@RequestBody SignUpParameter signUpParameter) {
+    String response = memberService.signUp(signUpParameter);
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/auth")
+  public ResponseEntity<String> auth(@RequestParam(name = "email") String email,
+      @RequestParam(name = "code") String code) {
+    String response = memberService.auth(email, code);
+    return ResponseEntity.ok(response);
+  }
+
+}

--- a/src/main/java/com/mymusiclist/backend/member/domain/MemberEntity.java
+++ b/src/main/java/com/mymusiclist/backend/member/domain/MemberEntity.java
@@ -1,0 +1,43 @@
+package com.mymusiclist.backend.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long memberId;
+
+  @Column(unique = true)
+  private String email;
+
+  private String password;
+  private String name;
+  private String nickname;
+  private LocalDateTime regDate;
+  private LocalDateTime modDate;
+  private Boolean auth;
+  private String authCode;
+  private String imageUrl;
+  private String introduction;
+  private String status;
+  private Boolean adminYn;
+  private String passwordAuthCode;
+  private LocalDateTime passwordDate;
+}

--- a/src/main/java/com/mymusiclist/backend/member/dto/MemberDto.java
+++ b/src/main/java/com/mymusiclist/backend/member/dto/MemberDto.java
@@ -1,0 +1,54 @@
+package com.mymusiclist.backend.member.dto;
+
+import com.mymusiclist.backend.member.domain.MemberEntity;
+import com.mymusiclist.backend.member.dto.parameter.SignUpParameter;
+import com.mymusiclist.backend.type.MemberStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberDto {
+
+  private Long memberId;
+  private String email;
+  private String password;
+  private String name;
+  private String nickname;
+  private LocalDateTime regDate;
+  private LocalDateTime modDate;
+  private Boolean auth;
+  private String authCode;
+  private String imageUrl;
+  private String introduction;
+  private String status;
+  private Boolean adminYn;
+  private String passwordAuthCode;
+  private LocalDateTime passwordDate;
+
+  public static MemberEntity signUpInput(SignUpParameter signUpParameter) {
+    String uuid = UUID.randomUUID().toString();
+    String encPassword = BCrypt.hashpw(signUpParameter.getPassword(), BCrypt.gensalt());
+
+    return MemberEntity.builder()
+        .email(signUpParameter.getEmail())
+        .password(encPassword)
+        .name(signUpParameter.getName())
+        .nickname(signUpParameter.getNickname())
+        .regDate(LocalDateTime.now())
+        .auth(false).authCode(uuid)
+        .imageUrl(signUpParameter.getImageUrl())
+        .introduction(signUpParameter.getIntroduction())
+        .status(MemberStatus.WAITING_FOR_APPROVAL.getDescription())
+        .build();
+  }
+}

--- a/src/main/java/com/mymusiclist/backend/member/dto/parameter/SignUpParameter.java
+++ b/src/main/java/com/mymusiclist/backend/member/dto/parameter/SignUpParameter.java
@@ -1,0 +1,23 @@
+package com.mymusiclist.backend.member.dto.parameter;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignUpParameter {
+
+  private String email;
+  private String password;
+  private String checkPassword;
+  private String name;
+  private String nickname;
+  private String imageUrl;
+  private String introduction;
+}

--- a/src/main/java/com/mymusiclist/backend/member/repository/MemberRepository.java
+++ b/src/main/java/com/mymusiclist/backend/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.mymusiclist.backend.member.repository;
+
+import com.mymusiclist.backend.member.domain.MemberEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
+
+  Optional<MemberEntity> findByEmail(String email);
+}

--- a/src/main/java/com/mymusiclist/backend/member/service/MemberService.java
+++ b/src/main/java/com/mymusiclist/backend/member/service/MemberService.java
@@ -1,0 +1,13 @@
+package com.mymusiclist.backend.member.service;
+
+import com.mymusiclist.backend.member.dto.parameter.SignUpParameter;
+import java.net.URISyntaxException;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface MemberService {
+
+  String signUp(SignUpParameter signUpParameter);
+
+  String auth(String email, String code);
+}

--- a/src/main/java/com/mymusiclist/backend/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/mymusiclist/backend/member/service/MemberServiceImpl.java
@@ -1,0 +1,94 @@
+package com.mymusiclist.backend.member.service;
+
+import com.mymusiclist.backend.components.MailComponents;
+import com.mymusiclist.backend.exception.impl.DuplicateEmailException;
+import com.mymusiclist.backend.exception.impl.InvalidAuthCodeException;
+import com.mymusiclist.backend.exception.impl.InvalidEmailException;
+import com.mymusiclist.backend.exception.impl.InvalidPasswordConfirmationException;
+import com.mymusiclist.backend.exception.impl.NotFoundMemberException;
+import com.mymusiclist.backend.member.domain.MemberEntity;
+import com.mymusiclist.backend.member.dto.MemberDto;
+import com.mymusiclist.backend.member.dto.parameter.SignUpParameter;
+import com.mymusiclist.backend.member.repository.MemberRepository;
+import com.mymusiclist.backend.type.MemberStatus;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.validator.routines.EmailValidator;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+  private final MemberRepository memberRepository;
+  private final MailComponents mailComponents;
+
+  @Override
+  @Transactional
+  public String signUp(SignUpParameter signUpParameter) {
+
+    Optional<MemberEntity> byEmail = memberRepository.findByEmail(signUpParameter.getEmail());
+    if (byEmail.isPresent()) {
+      throw new DuplicateEmailException();
+    }
+
+    if (!signUpParameter.getPassword().equals(signUpParameter.getCheckPassword())) {
+      throw new InvalidPasswordConfirmationException();
+    }
+
+    if (!isValidEmail(signUpParameter.getEmail())) {
+      throw new InvalidEmailException();
+    }
+
+    MemberEntity memberEntity = MemberDto.signUpInput(signUpParameter);
+    memberRepository.save(memberEntity);
+
+    String email = signUpParameter.getEmail();
+    String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+    String title = "MyMusicList 회원인증";
+    String message = "<h3>MyMusicList 회원가입에 성공했습니다. 아래의 링크를 클릭하셔서 회원인증을 완료해주세요.</h3>" +
+        "<div><a href='" + baseUrl + "/member/auth?email=" + email + "&code="
+        + memberEntity.getAuthCode() + "'> 인증 링크 </a></div>";
+    mailComponents.sendMail(email, title, message);
+
+    return "가입한 이메일을 확인해 회원인증을 진행해주세요.";
+  }
+
+  @Override
+  @Transactional
+  public String auth(String email, String code) {
+
+    Optional<MemberEntity> byEmail = memberRepository.findByEmail(email);
+    if (byEmail.isEmpty()) {
+      throw new NotFoundMemberException();
+    }
+    MemberEntity member = byEmail.get();
+
+    if (!code.equals(member.getAuthCode())) {
+      throw new InvalidAuthCodeException();
+    }
+
+    MemberEntity memberEntity = MemberEntity.builder()
+        .memberId(member.getMemberId())
+        .email(member.getEmail())
+        .password(member.getPassword())
+        .name(member.getName())
+        .nickname(member.getNickname())
+        .regDate(member.getRegDate())
+        .auth(true)
+        .authCode(member.getAuthCode())
+        .imageUrl(member.getImageUrl())
+        .introduction(member.getIntroduction())
+        .status(MemberStatus.ACTIVE.getDescription())
+        .build();
+    memberRepository.save(memberEntity);
+
+    return "인증을 완료 했습니다.";
+  }
+
+  private boolean isValidEmail(String email) {
+    return EmailValidator.getInstance().isValid(email);
+  }
+}

--- a/src/main/java/com/mymusiclist/backend/type/MemberStatus.java
+++ b/src/main/java/com/mymusiclist/backend/type/MemberStatus.java
@@ -1,0 +1,15 @@
+package com.mymusiclist.backend.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberStatus {
+
+  WAITING_FOR_APPROVAL("가입대기"),
+  ACTIVE("이용중"),
+  SUSPENDED("계정정지");
+
+  private final String description;
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- signUpParameter를 RequestBody로 POST 요청을 보내면 signUpParameter의 email로 인증링크가 있는 메일이 가게 되고 인증링크를 통해 인증이되면 회원의 상태가 가입대기에서 이용중으로 변경되면서 정상적으로 가입이 완료가 됩니다.
- 중복가입을 방지하기 위해 DB에서 이미 가입한 email 정보가 있으면 Exception이 발생하게 했습니다.
- 비밀번호와 확인용 비밀번호가 다르면 Exception이 발생하도록 했습니다.
- email의 형식이 이상하면 Exception이 발생하도록 했습니다.
- 가입인증 중에 email에 해당하는 회원이 없으면 Exception이 발생하도록 했습니다.
- 가입인증 중에 인증코드가 DB에 저장되어 있는 것과 다를 때 Exception이 발생하도록 했습니다.

**TO-BE**
- 회원탈퇴 기능은 게시글과 댓글 기능이 완성 된 후 구현 할 예정

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
